### PR TITLE
Autocomplete work

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
 
     "main": "./src/api",
     "bugs": {"url": "http://github.com/caolan/kanso/issues"},
-    "bin": {"kanso": "./bin/kanso"}
+    "bin": {
+        "kanso": "./bin/kanso",
+        "kanso_completions": "./scripts/autocomp.js"
+    }
 }

--- a/scripts/autocomp.sh
+++ b/scripts/autocomp.sh
@@ -1,17 +1,9 @@
-# Remember the absolute path to the autocompleter.
-_kanso_autocomp_js=$(dirname "$BASH_SOURCE")/autocomp.js
-if [ `uname` = "Darwin" ]; then
-    _kanso_autocomp_js=$(ruby -e "puts File.expand_path('$_kanso_autocomp_js')")
-else
-    _kanso_autocomp_js=$(readlink -f "$_kanso_autocomp_js")
-fi
-
 _compListener() {
   local curw
   COMPREPLY=()
   curw=${COMP_WORDS[COMP_CWORD]}
 
-  COMPREPLY=($($_kanso_autocomp_js ${COMP_WORDS[@]}))
+  COMPREPLY=($(kanso_completions ${COMP_WORDS[@]}))
   return 0
 }
 #complete -F _compListener -o nospace kanso


### PR DESCRIPTION
I'm not super happy with this, so I branched off of "dev.

The goal is that we can source `scripts/autocomp.sh` and then typing `kanso <TAB>` works. Bash needs to run the `autocomp.js` script, and the idea is that Kanso doesn't worry about $NODE_PATH or $KANSO_DIR. That is NPM's problem.

The first commit set a "global" Bash variable with the location to the script. Ideally Kanso would not pollute the variable space like that.

My next try was to add a new "bin" command, which most people needn't know about: `kanso_completions`. NPM installs this into the $PATH, and the completer can use it. I'm not happy about adding a new command. In particular, if you type `kanso<TAB>`, instead of getting a space because that is a unique command, now Bash beeps because it could mean either "kanso" or "kanso_completions". I suppose many people type "kanso<SPACE>" so maybe it's fine this way.

Alternative idea 1:

I investigated the `npm run-script` command. Instead of a "bin" field, you can use "scripts" similarly. Unfortunately, `npm run-script` does not pass command-line arguments through to the script. So we would have to maybe export a variable with `${COMP_WORDS[@]}`, and autocomp.js can pull it from process.env. Then unset it after the command runs to avoid polluting the variable space again. This seems like a lot of work.

Alternative idea 2:

Add a kanso command, `kanso completions` which does the same thing as autocomp.js. Perhaps it could be undocumented and "hidden" (at least for Kanso _users_, not Kanso developers). The advantage is, if "kanso" is in your path, then of course "kanso completions" would work. `autocomp.sh` stays simple too. Let me know if you think it's worth it. (I've never looked into the commands, especially considering this one might be hidden.)
