### PR TITLE
Fix package.json error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "url": "http://github.com/caolan/kanso.git"
     },
 
-    "engines": {"node": "~0.4.0 <0.6.6"},
+    "engines": {"node": "~0.4.0 ~0.6.6"},
     "bugs": {"url": "http://github.com/caolan/kanso/issues"},
     "bin": {
         "kanso": "./bin/kanso",


### PR DESCRIPTION
Looks like I made a typo or something, causing a pretty severe semantic problem in the package.json. NPM refused to install kanso on the only Node release that actually runs it!
