### PR TITLE
No URI-encoding for usernames/passwords

### DIFF
--- a/src/kanso/commands/listdb.js
+++ b/src/kanso/commands/listdb.js
@@ -108,7 +108,7 @@ exports.listdb = function (url, callback) {
     if (parsed.auth && parsed.auth.split(':').length === 1) {
         utils.getPassword(function (err, password) {
             delete parsed.host;
-            parsed.auth += ':' + encodeURIComponent(password);
+            parsed.auth += ':' + password;
             url = urlFormat(parsed);
             console.log('');
             exports.listdb(url, callback);

--- a/src/kanso/commands/publish.js
+++ b/src/kanso/commands/publish.js
@@ -42,7 +42,7 @@ exports.publish = function (dir, repo, options, callback) {
     if (parsed.auth && parsed.auth.split(':').length === 1) {
         utils.getPassword(function (err, password) {
             delete parsed.host;
-            parsed.auth += ':' + encodeURIComponent(password);
+            parsed.auth += ':' + password;
             repo = urlFormat(parsed);
             exports.publish(dir, repo, options, callback);
         });

--- a/src/kanso/commands/push.js
+++ b/src/kanso/commands/push.js
@@ -183,7 +183,7 @@ exports.push = function (dir, cfg, doc, url, callback) {
     if (parsed.auth && parsed.auth.split(':').length === 1) {
         utils.getPassword(function (err, password) {
             delete parsed.host;
-            parsed.auth += ':' + encodeURIComponent(password);
+            parsed.auth += ':' + password;
             url = urlFormat(parsed);
             exports.push(dir, cfg, doc, url, callback);
         });

--- a/src/kanso/commands/unpublish.js
+++ b/src/kanso/commands/unpublish.js
@@ -55,7 +55,7 @@ exports.unpublish = function (repo, name, version, options, callback) {
     if (parsed.auth && parsed.auth.split(':').length === 1) {
         utils.getPassword(function (err, password) {
             delete parsed.host;
-            parsed.auth += ':' + encodeURIComponent(password);
+            parsed.auth += ':' + password;
             repo = urlFormat(parsed);
             exports.unpublish(repo, name, version, options, callback);
         });

--- a/src/kanso/commands/upload.js
+++ b/src/kanso/commands/upload.js
@@ -129,7 +129,7 @@ exports.pushDocs = function (path, url, options, callback) {
     if (parsed.auth && parsed.auth.split(':').length === 1) {
         utils.getPassword(function (err, password) {
             delete parsed.host;
-            parsed.auth += ':' + encodeURIComponent(password);
+            parsed.auth += ':' + password;
             url = urlFormat(parsed);
             exports.pushDocs(path, url, options, callback);
         });

--- a/src/kanso/couchdb.js
+++ b/src/kanso/couchdb.js
@@ -171,8 +171,7 @@ CouchDB.prototype.client = function (method, path, data, callback) {
     }
 
     if (this.instance.auth) {
-        var auth = decodeURIComponent(this.instance.auth);
-        var enc = new Buffer(auth).toString('base64');
+        var enc = new Buffer(this.instance.auth).toString('base64');
         headers.Authorization = "Basic " + enc;
     }
 

--- a/src/kanso/repository.js
+++ b/src/kanso/repository.js
@@ -494,8 +494,7 @@ exports.download = function (file, callback) {
         }
         var headers = {};
         if (urlinfo.auth) {
-            var auth = decodeURIComponent(urlinfo.auth);
-            var enc = new Buffer(auth).toString('base64');
+            var enc = new Buffer(urlinfo.auth).toString('base64');
             headers.Authorization = "Basic " + enc;
         }
         var request = proto.request({

--- a/src/kanso/utils.js
+++ b/src/kanso/utils.js
@@ -509,7 +509,7 @@ exports.getAuth = function (url, callback) {
                 return callback(err);
             }
             delete parsed.host;
-            parsed.auth += ':' + encodeURIComponent(password);
+            parsed.auth += ':' + password;
             console.log('');
             callback(null, urlFormat(parsed));
         });
@@ -526,8 +526,7 @@ exports.getAuth = function (url, callback) {
                 if (err) {
                     return callback(err);
                 }
-                parsed.auth = encodeURIComponent(username) + ':' +
-                              encodeURIComponent(password);
+                parsed.auth = username + ':' + password;
                 callback(null, urlFormat(parsed));
             });
         });


### PR DESCRIPTION
URI-encoded usernames and passwords caused url.urlParse to
fail [1], which meant that usernames and passwords with
characters that needed to be URI-encoded couldn't be used.

This patch removes the URI-encoding of usernames and passwords,
and the corresponding decodeURIComponent calls couchdb.js and
repository.js. This does not affect existing functionality as
the auth string is base64-encoded before being added to the
Authorization header.

[1] https://github.com/joyent/node/issues/1163
