### PR TITLE
Adding support to the kanso transform csv command for different delimiter characters

### DIFF
--- a/lib/commands/transform.js
+++ b/lib/commands/transform.js
@@ -43,6 +43,10 @@ exports.usage = '' +
 '                  converting from CSV. This should be a string,\n' +
 '                  comma-separated.\n' +
 '                  Example: --format="string,number,boolean,string"\n' +
+'  -d, --delimiter The delimiter to use in when converting from CSV.\n' +
+'                  A comma is the default value.\n' +
+'                  Passing tab will use a \\t character\n' +
+'                  Example: --delimiter="tab"\n' +
 '  -m, --module    The module to load a map function from.\n' +
 '  -s, --src       The source code to use for a map function.';
 
@@ -104,6 +108,7 @@ exports.run = function (settings, args, commands) {
         'indent': {match: ['--indent','-i'], value: true},
         'url':    {match: ['--url','-u'],    value: true},
         'format': {match: ['--format','-F'], value: true},
+        'delimiter': {match: ['--delimiter','-d'], value: true},
         'module': {match: ['--module','-m'], value: true},
         'src':    {match: ['--src','-s'], value: true}
     });
@@ -328,13 +333,18 @@ exports.csv = function (db, source, target, options) {
         });
     }
 
+    var delimiter = options.delimiter || ",";
+    if(delimiter.toLowerCase() === 'tab') {
+        delimiter = "\t";
+    }
+
     var outfile = fs.createWriteStream(target);
     outfile.on('error', function (err) {
         logger.error(err);
     });
     outfile.on('open', function (fd) {
         outfile.write('[');
-        var csvfile = csv().fromPath(source);
+        var csvfile = csv().fromPath(source,{"delimiter": delimiter});
         outfile.on('drain', function () {
             csvfile.readStream.resume();
         });


### PR DESCRIPTION
I need to be able to transform files written in TSV, similar to this request:

https://groups.google.com/group/kanso/browse_thread/thread/516505b0d0eb6e10

I have added the -d --delimiter option to the transform command.  I found that passing the tab (\t) character was problematic so I allowed the word tab to be passed.  The -d option defaults to a comma so it is backwards compatible.
