### PR TITLE
Overwrite settings from kanso.json with environment-specific settings from .kansorc

### DIFF
--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -73,7 +73,9 @@ exports.run = function (settings, args) {
 
             // these options will override values in kanso.json
             // the 'id' and 'open' options are not relevant to that data
-            var opt = {minify: a.options.minify, baseURL: a.options.baseURL};
+            var opt = env.overrides || {};
+            opt.minify = a.options.minify;
+            opt.baseURL = a.options.baseURL;
 
             exports.loadApp(dir, url, opt, settings,
                 function (err, url, cfg, doc) {

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -43,7 +43,7 @@ exports.load = function (name, paths, source, options, callback) {
         }
 
         // extend kanso.json values with options passed from command-line
-        _.extend(pcache[name].cfg, options);
+        exports.merge(pcache[name].cfg, options);
 
         // set root package's root property
         pcache[name].root = true;


### PR DESCRIPTION
I had to change `_.extend()` to `exports.merge()` in packages.js:46,
because, if a section in kanso.json was only partially redefined in
.kansorc, underscore would replace that whole section.

---

For example, if one defined in `kanso.json`

``` javascript
...
less: {
    compile: [ "style.less", "mobile.less" ],
    compress: false
}
```

and tried to overwrite only the `compress`-part like this in `.kansorc`

``` javascript
exports.env = {
    ...
    'production': {
        overrides: {
            less: { compress: true }
        }
    }
```

the resulting settings object passed to the packages was

``` javascript
...
less: {
    compress: true
}
```

and **not**

``` javascript
...
less: {
    compile: [ "style.less", "mobile.less" ],
    compress: true
}
```
