### PR TITLE
Support uploading directories in `kanso push`

### DIFF
--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -8,6 +8,8 @@ var logger = require('../logger'),
     urlParse = require('url').parse,
     urlFormat = require('url').format,
     events = require('events'),
+    stream = require('stream'),
+    path_lib = require('path'),
     fs = require('fs');
 
 
@@ -21,12 +23,14 @@ exports.usage = '' +
 '         it will use the "default" env in your .kansorc if available\n' +
 '\n'+
 'Options:\n' +
-'  -f, --force      Ignore document conflict errors and upload anyway';
+'  -f, --force      Ignore document conflict errors and upload anyway' +
+'  -d, --json-dirs  Treat directories as one document';
 
 
 exports.run = function (settings, args, commands) {
     var a = argParse(args, {
-        'force': {match: ['--force','-f']}
+        'force': {match: ['--force','-f']},
+        'json_dirs': {match: ['--json-dirs','-d']}
     });
     if (!a.positional[0]) {
         logger.error('No data file or directory specified');
@@ -65,6 +69,7 @@ exports.pushDoc = function (url, path, doc, i, options, callback) {
     db.save(doc._id, doc, {force: options.force}, function (err, res) {
         if (!err) {
             logger.info('Saved',
+                //(res._id || res.id) + ' (' + path + ', entry: ' + i + ')'
                 (res._id || res.id) + ' (' + path + ', entry: ' + i + ')'
             );
         }
@@ -84,8 +89,17 @@ exports.pushDocs = function (url, path, options, callback) {
         if (err) {
             return callback(err);
         }
+
+        var finder = exports.find;
+        var reader = exports.readFile;
+        if (options.json_dirs) {
+            finder = exports.find_json;
+            reader = exports.readFileRecursive;
+        }
+
         console.log('Uploading docs to ' + utils.noAuthURL(url));
-        exports.find(path, function (err, files) {
+        console.error('Opts: ' + JSON.stringify(options))
+        finder(path, function (err, files) {
             if (err) {
                 return callback(err);
             }
@@ -94,7 +108,7 @@ exports.pushDocs = function (url, path, options, callback) {
 
             async.forEachSeries(files, function (f, cb) {
                 logger.info('Reading', f);
-                exports.readFile(f, url, options, function (err, succ, total) {
+                reader(f, url, options, function (err, succ, total) {
                     if (err) {
                         cb(err);
                     }
@@ -128,10 +142,8 @@ exports.pushDocs = function (url, path, options, callback) {
     });
 }
 
-exports.readFile = function (path, url, options, callback) {
+exports.pushDocStream = function (rstream, url, path, options, callback) {
     var pstream = json.createParseStream();
-    var rstream = fs.createReadStream(path);
-    rstream.pause();
 
     var total = 0;
     var successful = 0;
@@ -172,9 +184,167 @@ exports.readFile = function (path, url, options, callback) {
             });
         }
     });
+
     rstream.pipe(pstream);
     rstream.resume();
 };
+
+exports.readFile = function (path, url, options, callback) {
+    var rstream = fs.createReadStream(path);
+    rstream.pause();
+    exports.pushDocStream(rstream, url, path, options, callback);
+};
+
+exports.readDir = function (path, url, options, callback) {
+    var rstream = createJSONDirStream(path);
+    rstream.pause();
+    exports.pushDocStream(rstream, url, path, options, callback);
+};
+
+exports.readFileRecursive = function (path, url, options, callback) {
+    fs.stat(path, function (err, stats) {
+        if (err) {
+            callback(err);
+        }
+        else if (stats.isDirectory()) {
+            exports.readDir(path, url, options, callback);
+        }
+        else if (stats.isFile()) {
+            exports.readFile(path, url, options, callback);
+        }
+        else {
+            return callback(new Error('Not a file or directory: ' + path));
+        }
+    });
+};
+
+function createJSONDirStream(path) {
+    var rstream = new stream.Stream;
+    rstream.writable = false;
+    rstream.readable = true;
+
+    rstream.pending = [];
+    rstream.setEncoding = function() {};
+    rstream.pause = function() { rstream.paused = true };
+    rstream.resume = function() {
+        rstream.paused = false;
+        rstream.flush();
+    };
+
+    function emit(type, value) {
+        rstream.pending.push([type, value]);
+        rstream.flush();
+    }
+
+    var data = [];
+    rstream.flush = function () {
+        if (!rstream.paused && rstream.pending.length > 0) {
+            var oldest = rstream.pending.shift(),
+                type = oldest[0],
+                value = oldest[1];
+
+            if(type === 'data') {
+                data.push(oldest[1]);
+            }
+            else {
+                //console.error('EMIT: ' + type + ': ' + require('util').inspect(value))
+                rstream.emit(type, value);
+            }
+            rstream.flush();
+        }
+    };
+
+    function end() {
+        if (data.length) {
+            rstream.emit('data', data.join(''));
+        }
+        rstream.emit('end');
+    }
+
+    readdir(path, 0);
+    return rstream;
+
+    function readdir(dir, depth) {
+        // Introduce a new object.
+        console.error('readdir: ' + dir)
+        emit('data', '{');
+
+        fs.readdir(dir, function(err, files) {
+            if (err) {
+                return emit('error', err);
+            }
+
+            var key_number = 0;
+            async.forEachSeries(files, readfile, function(err) {
+                if (err) {
+                    return emit('error', err);
+                }
+                emit('data', '}');
+                if(depth === 0) {
+                    end();
+                }
+            });
+
+            function readfile(file, file_callback, x) {
+                var path = path_lib.join(dir, file);
+                fs.stat(path, function(err, stats) {
+                    if (err) {
+                        file_callback(err);
+                    }
+
+                    if (file[0] === '.') {
+                        return file_callback();
+                    }
+
+                    key_number += 1;
+                    if (key_number > 1) {
+                        emit('data', ',');
+                    }
+
+                    var key_name = file.replace(/\.\w+$/, '');
+                    emit('data', JSON.stringify(key_name));
+                    emit('data', ':');
+
+                    if (stats.isDirectory()) {
+                        readdir(path, depth + 1);
+                    }
+                    if (stats.isFile()) {
+                        fs.readFile(path, 'utf8', function (err, data) {
+                            if (err) {
+                                return file_callback(err);
+                            }
+
+                            // .json files are imported directly, but otherwise
+                            // their contents are represented as JSON (often a
+                            // quoted string).
+                            if(/\.json$/.test(file)) {
+                                data = JSON.parse(data);
+                            }
+                            else {
+                                try {
+                                    data = JSON.parse(data);
+                                } catch (parse_err) {
+                                    // Nothing to do, keep data as a string.
+                                }
+
+                                // Strip the newline from special values.
+                                if (depth === 0 && (file === '_id' || file === '_rev')) {
+                                    data = data.trimRight();
+                                }
+                            }
+                            emit('data', JSON.stringify(data));
+                            file_callback();
+                        });
+                    }
+                    else {
+                        logger.error('Unknown file: ' + path);
+                    }
+                });
+            }
+        });
+    }
+};
+
 
 /**
  * Find all .json files below a given path, recursing through subdirectories
@@ -185,6 +355,59 @@ exports.readFile = function (path, url, options, callback) {
 
 exports.find = function (p, callback) {
     utils.find(p, exports.filenameFilter(p), callback);
+};
+
+/**
+ * Find .json files and directories at a given path
+ *
+ * @param {String} p - the path to search
+ * @param {Function} callback
+ */
+
+exports.find_json = function (p, callback) {
+    var is_json_file = exports.filenameFilter(p);
+
+    fs.stat(p, function (err, stats) {
+        if (err) {
+            return callback(err);
+        }
+
+        else if (stats.isFile()) {
+            callback(null, p);
+        }
+
+        else if (stats.isDirectory()) {
+            // Get everything one level deep in here.
+            fs.readdir(p, function (err, files) {
+                if (err) {
+                    return callback(err);
+                }
+                var paths = files.map(function (f) {
+                    return path_lib.join(p, f);
+                });
+                async.filter(paths, is_json_or_dir, function(paths) {
+                    return callback(null, paths)
+                });
+
+                function is_json_or_dir(path, filter_callback) {
+                    fs.stat(path, function(err, stats) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        if (stats.isDirectory()) {
+                            return filter_callback(true);
+                        }
+                        if (stats.isFile() && is_json_file(path)) {
+                            return filter_callback(true);
+                        }
+                        else {
+                            return filter_callback(false);
+                        }
+                    });
+                }
+            });
+        }
+    });
 };
 
 


### PR DESCRIPTION
Be careful what you wish for :)

I have modifications to the traditional-couchapp package for `_docs/` support. It does not upload them like @benoitc's CouchApp; but at least it ignores the directory and prints a warning that you should use `kanso upload`.

The next problem, which this pull request fixes, is that documents can be represented as directories, where each filename is a key in the doc, and the file contents are the value. Nested directories make nested objects.

Unfortunately, `kanso upload` does not support that, so this patch allows me to at least get my work done via `kanso upload --json-dirs`.

I do not recommend merging this as-is. It's quite bad. However I wanted you to see it so we can talk about a better long-term solution. Thanks.
