### PR TITLE
FIX: kanso pack package_folder fails if .kasnoignore exists

### DIFF
--- a/lib/tar.js
+++ b/lib/tar.js
@@ -111,11 +111,11 @@ exports.create = function (outfile, dir, callback) {
                 if (ignores) {
                     if (is_bsd) {
                         args = args.slice(0, args.length-1).concat(
-                            ['-X', ignorefile, '.']
+                            ['-X', path.basename(ignorefile), '.']
                         );
                     }
                     else {
-                        args = args.concat(['-X', ignorefile]);
+                        args = args.concat(['-X', path.basename(ignorefile)]);
                     }
                 }
                 tar = spawn('tar', args, {cwd: dir});


### PR DESCRIPTION
executing kanso pack from outside the package folder will cause tar
to crash due to inability of reading package_folder/.kansoignore
