### PR TITLE
Fixed error message on `kanso publish`: tty.setRawMode: Use `process.stdin.setRawMode()` instead.

### DIFF
--- a/node_modules/prompt/lib/prompt.js
+++ b/node_modules/prompt/lib/prompt.js
@@ -79,7 +79,7 @@ prompt.start = function (options) {
     process.on('SIGINT', function () {
       stdout.write('\n');
       process.exit(1);
-    });   
+    });
   }
 
   prompt.emit('start');
@@ -376,14 +376,14 @@ prompt.readLine = function (callback) {
 //
 prompt.readLineHidden = function (callback) {
   var value = '';
-  
+
   //
   // Ignore errors from `.setRawMode()` so that `node-prompt` can
   // be scripted in child processes.
   //
-  try { tty.setRawMode(true) }
+  try { process.stdin.setRawMode(true) }
   catch (ex) { }
-  
+
   prompt.resume();
   stdin.on('error', callback);
   stdin.on('data', function data (line) {
@@ -392,7 +392,7 @@ prompt.readLineHidden = function (callback) {
       c = line[i];
       switch (c) {
         case '\n': case '\r': case '\r\n': case '\u0004':
-          tty.setRawMode(false);
+          process.stdin.setRawMode(false);
           stdin.removeListener('data', data);
           stdin.removeListener('error', callback);
           value = value.trim();


### PR DESCRIPTION
This has been fixed in `prompt 2.0`, however the 2.x extensions doesn't work. Therefore I gave it a shot in kanso directly.
