### PR TITLE
'kanso upload' should handle multi-line strings

### DIFF
--- a/lib/data-stream/ParseStream.js
+++ b/lib/data-stream/ParseStream.js
@@ -75,7 +75,9 @@ ParseStream.prototype.native = function Native(set) {
                 set(int ? parseInt(token) : parseFloat(token));
                 break;
             case 'string':
-                set(JSON.parse(token));
+                var new_tok = token.replace(/\n/g, '\\n');
+                new_tok = new_tok.replace(/\r/g, '\\r');
+                set(JSON.parse(new_tok));
                 break;
             default:
                 throw new SyntaxError("unexpected token "+token+". expecting native");


### PR DESCRIPTION
When uploading data using 'kanso upload', the parsing of the JSON string fails if the string contains a new line.  e.g.:

```
 mgmarino% cat tmp.json 
{
  "_id" : "'test'",
  "astring" : "test


 +1"
}
 mgmarino% kanso upload -f tmp.json http://127.0.0.1:5984/test
Uploading docs to http://127.0.0.1:5984/test
Reading tmp.json
Error: SyntaxError: Unexpected token 

    at Object.parse (native)
    at ParseStream.Native (/usr/local/lib/node_modules/kanso/lib/data-   stream/ParseStream.js:78:26)
```

This can be difficult to input data into JSON that is multi-line (e.g. scripts, etc.) so these multi-line strings should be properly escaped.  
