### PR TITLE
Make the push url available on the options so modules can use

### DIFF
--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -118,6 +118,7 @@ exports.loadApp = function (dir, url, options, settings, callback) {
     var build_start = new Date().getTime();
     // make the url available to the modules
     options._url = url;
+    options._utils = utils;
     packages.load(dir, paths, null, options, function (err, doc, cfg) {
         if (err) {
             if (callback) {


### PR DESCRIPTION
There are times where modules might want to do more things to the db on a push. This allows them to at least access the push url via the options object. its prefixed with a _ so options._url. The auth can't be passed (at least without a significant refactor) so the modules may have to prompt the user for a username/pass. Not elegant, but the modules can reuse utils.getAuth()
