### PR TITLE
Objects Merge: Ignoring Conflicts wasn't recursive

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -380,7 +380,7 @@ exports.merge = function (a, b, /*opt*/path, /*opt*/ignore_conflicts) {
 
     for (var k in b) {
         if (typeof b[k] === 'object' && !Array.isArray(b[k])) {
-            a[k] = exports.merge(a[k], b[k], path.concat([k]));
+            a[k] = exports.merge(a[k], b[k], path.concat([k]), ignore_conflicts);
         }
         else {
             if (a[k] && a[k] !== b[k] && !ignore_conflicts) {

--- a/test/test-lib-package.js
+++ b/test/test-lib-package.js
@@ -1,0 +1,19 @@
+
+var packages = require('../lib/packages');
+
+exports['mergeDeepObjectsIgnoringConflicts'] = function (test) {
+    var obj1 = {a: {x: 5}, b: {y: {z: 1}}};
+    var obj2 = {a: {t: 1}, b: {y: {z: 2, l: 5}}};
+    var objr = packages.merge(obj1, obj2, [], true);
+    test.same(objr, {a: {x: 5, t: 1}, b: {y: {z: 2, l: 5}}});
+    test.done();
+};
+
+exports['mergeWithArraysIgnoringConflicts'] = function (test) {
+    var obj1 = { a : 1, b : 2, c : 3, d: { x: { f: { p: true}}}};
+    var obj2 = { b : [4, 5, 6], d: { x: { f: { p: [9,8,7]}}}};
+    var objr = packages.merge(obj1, obj2, [], true);
+    test.same(objr, {a: 1, b: [4,5,6], c: 3, d: { x: { f: { p: [9,8,7]}}}});
+    test.done();
+};
+


### PR DESCRIPTION
The ignore_conflicts flag was not propagated to inner function calls,
leading to false error messages when overriding deeper properties of
objects.

Tests included.

Fixes #401.
