### PR TITLE
add option to skip conflicts when uploading

### DIFF
--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -21,12 +21,14 @@ exports.usage = '' +
 '         it will use the "default" env in your .kansorc if available\n' +
 '\n'+
 'Options:\n' +
-'  -f, --force      Ignore document conflict errors and upload anyway';
+'  -f, --force      Ignore document conflict errors and upload anyway\n' +
+'  -s, --skip       Skip document conflict errors and do not retry';
 
 
 exports.run = function (settings, args, commands) {
     var a = argParse(args, {
-        'force': {match: ['--force','-f']}
+        'force': {match: ['--force','-f']},
+        'skip': {match: ['--skip', '-s']}
     });
     if (!a.positional[0]) {
         logger.error('No data file or directory specified');
@@ -63,9 +65,17 @@ exports.pushDoc = function (url, path, doc, i, options, callback) {
         return logger.error('No _id defined for ' + path);
     }
     db.save(doc._id, doc, {force: options.force}, function (err, res) {
+        var skipped = false;
         if (!err) {
             logger.info('Saved',
                 (res._id || res.id) + ' (' + path + ', entry: ' + i + ')'
+            );
+        }
+        else if (err.error === 'conflict') {
+            err = null;
+            skipped = true;
+            logger.info('Skipped',
+                  (doc._id || doc.id) + ' (' + path + ', entry: ' + i + ')'
             );
         }
         else {
@@ -74,7 +84,7 @@ exports.pushDoc = function (url, path, doc, i, options, callback) {
             );
             logger.error(err);
         }
-        callback(err);
+        callback(err, skipped);
     });
 };
 
@@ -90,18 +100,21 @@ exports.pushDocs = function (url, path, options, callback) {
                 return callback(err);
             }
             var all_successful = 0;
+            var all_skipped = 0;
             var all_total = 0;
 
             async.forEachSeries(files, function (f, cb) {
                 logger.info('Reading', f);
-                exports.readFile(f, url, options, function (err, succ, total) {
+                exports.readFile(f, url, options, function (err, succ, skip, total) {
                     if (err) {
                         cb(err);
                     }
                     all_successful += succ;
+                    all_skipped += skip;
                     all_total += total;
                     if (succ % 100 !== 0) {
-                        logger.info('Uploaded ' + succ+ ' docs');
+                        logger.info('Uploaded ' + (succ - skip) + ' docs');
+                        logger.info('Skipped ' + skip + ' docs');
                     }
                     cb();
                 });
@@ -112,13 +125,13 @@ exports.pushDocs = function (url, path, options, callback) {
                 }
                 if (all_total === all_successful) {
                     logger.end(
-                        'Uploaded ' + all_successful + ' of ' +
+                        'Uploaded ' + (all_successful - all_skipped) + ' of ' +
                         all_total + ' docs'
                     );
                 }
                 else {
                     logger.error(
-                        'Uploaded ' + all_successful + ' of ' +
+                        'Uploaded ' + (all_successful - all_skipped) + ' of ' +
                         all_total + ' docs'
                     );
                 }
@@ -135,6 +148,7 @@ exports.readFile = function (path, url, options, callback) {
 
     var total = 0;
     var successful = 0;
+    var skipped = 0;
     var waiting = 0;
     var ev = new events.EventEmitter();
 
@@ -142,11 +156,12 @@ exports.readFile = function (path, url, options, callback) {
         rstream.pause();
         waiting++;
         total++;
-        exports.pushDoc(url, path, doc, total, options, function (err) {
+        exports.pushDoc(url, path, doc, total, options, function (err, skip) {
             if (err) {
                 logger.error(err);
             }
             else {
+                if(skip) skipped++;
                 successful++;
                 if (successful % 100 === 0 && successful != 0) {
                     logger.info('Uploaded ' + successful + ' docs');
@@ -162,12 +177,12 @@ exports.readFile = function (path, url, options, callback) {
     });
     pstream.on('end', function () {
         if (waiting <= 0) {
-            callback(null, successful, total);
+            callback(null, successful, skipped, total);
         }
         else {
             ev.on('doc_pushed', function () {
                 if (waiting <= 0) {
-                    callback(null, successful, total);
+                    callback(null, successful, skipped, total);
                 }
             });
         }


### PR DESCRIPTION
The option --skip or -s for `kanso upload` makes the command
ignore document update conflicts and report them as "skipped"
While still treating this as success (errlevel 0)

The reason for this modification is to allow for automating our
deployment which ensure the presence of a few documents but
still allows them to be modified later by the application

I could not find how to write or even run tests, so I'm expecting some pointers for that so I can add proper testing to this.
