### PR TITLE
add some tests for SKIP feature of command upload

### DIFF
--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -64,14 +64,19 @@ exports.pushDoc = function (url, path, doc, i, options, callback) {
     if (!doc._id) {
         return logger.error('No _id defined for ' + path);
     }
-    db.save(doc._id, doc, {force: options.force}, function (err, res) {
+    db.save(doc._id, doc, {force: options.force}, 
+        exports.pushDocCallback(path, doc, i, options, logger, callback));
+};
+
+exports.pushDocCallback = function (path, doc, i, options, logger, callback) {
+    return function (err, res) {
         var skipped = false;
         if (!err) {
             logger.info('Saved',
                 (res._id || res.id) + ' (' + path + ', entry: ' + i + ')'
             );
         }
-        else if (err.error === 'conflict') {
+        else if (err.error === 'conflict' && options.skip) {
             err = null;
             skipped = true;
             logger.info('Skipped',
@@ -85,8 +90,8 @@ exports.pushDoc = function (url, path, doc, i, options, callback) {
             logger.error(err);
         }
         callback(err, skipped);
-    });
-};
+    };
+}
 
 exports.pushDocs = function (url, path, options, callback) {
     var db = couchdb(url);

--- a/test/test-command-upload.js
+++ b/test/test-command-upload.js
@@ -1,0 +1,76 @@
+var couchdb = require('../lib/couchdb');
+var dbname = 'upload-test-db'
+
+var loggerMock = {
+  success: function () {},
+  info: function () {},
+  error: function () {}
+}
+
+var pushDocCallback = require('../lib/commands/upload').pushDocCallback;
+
+var exampleDoc = {
+  _id: 'some-doc'
+}
+
+var savedDoc = {
+  _id: 'some-doc',
+  _rev: '1-654321'
+}
+
+exports['pushDocCallback should callback with no argument on success'] = function (test) {
+  test.expect(1);
+  var cb = pushDocCallback('/some/path', exampleDoc, 0, {}, loggerMock, assertions);
+
+  cb(null, savedDoc);
+
+  function assertions (err) {
+    test.ok(!err, 'there should be no error');
+    test.done();
+  }
+}
+
+
+
+exports['pushDocCallback should callback with the error if it gets one'] = function (test) {
+  test.expect(1);
+  var cb = pushDocCallback('/some/path', exampleDoc, 0, {}, loggerMock, assertions);
+  var expected = new Error('some error');
+
+  cb(expected);
+
+  function assertions (err) {
+    test.equal(err, expected, 'there should be an error');
+    test.done();
+  }
+}
+
+exports['pushDocCallback should callback with no error and a skip boolean if the option skipped is active'] = function (test) {
+  test.expect(2);
+  var cb = pushDocCallback('/some/path', exampleDoc, 0, {skip: true}, loggerMock, assertions);
+  var expected = new Error('some error');
+  expected.error = 'conflict';
+
+  cb(expected);
+
+  function assertions (err, skip) {
+    test.ok(!err, 'There should be no error');
+    test.equal(skip, true, 'The skip flag should be set');
+    test.done();
+  }
+}
+
+exports['pushDocCallback should callback with an error on conflicts if skip is not set'] = function (test) {
+  test.expect(1);
+  var cb = pushDocCallback('/some/path', exampleDoc, 0, {skip: false}, loggerMock, assertions);
+  var expected = new Error('some error');
+  expected.error = 'conflict';
+
+  cb(expected);
+
+  function assertions (err, skip) {
+    test.equal(err, expected, 'there should be an error');
+    test.done();
+  }
+}
+


### PR DESCRIPTION
Adding tests helped me see an error in the implementation. All uploads were effectively skipped, with or without the option. This is now fixed.
