### PR TITLE
Adds --source-dir option to kanso install command.

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -43,7 +43,8 @@ exports.usage = '' +
 '\n' +
 'Options:\n' +
 '  --repository   Source repository URL (otherwise uses values in kansorc)\n' +
-'  --package-dir  Output directory (defaults to "./packages")';
+'  --package-dir  Output directory (defaults to "./packages")\n' +
+'  --source-dir   Local  directory to source dependencies from';
 
 
 /**
@@ -56,7 +57,8 @@ exports.usage = '' +
 exports.run = function (settings, args) {
     var a = argParse(args, {
         'repository': {match: '--repository', value: true},
-        'target_dir': {match: '--package-dir', value: true}
+        'target_dir': {match: '--package-dir', value: true},
+        'source_dir': {match: '--source-dir', value: true}
     });
 
     var opt = a.options;
@@ -199,6 +201,7 @@ exports.installDir = function (dir, opt, callback) {
             return callback();
         }
         var sources = [
+            exports.dirSource(opt.source_dir),
             exports.dirSource(opt.target_dir),
             exports.repoSource(opt.repositories)
         ];
@@ -274,6 +277,7 @@ exports.installName = function (name, opt, callback) {
             return callback(err);
         }
         var sources = [
+            exports.dirSource(opt.source_dir),
             exports.dirSource(opt.target_dir),
             exports.repoSource(opt.repositories)
         ];
@@ -496,6 +500,7 @@ exports.installFile = function (filename, opt, callback) {
                 return callback(err);
             }
             var sources = [
+                exports.dirSource(opt.source_dir),
                 exports.dirSource(opt.target_dir),
                 exports.repoSource(opt.repositories)
             ];


### PR DESCRIPTION
Allows to resolve dependencies from local packages without publishing
them. In my case I use multiple packages which all depend on a common
package with some common code and functionality. There's no sense in
publishing it, because it is highly app-specific.
--source-dir option should point to the directory above the local
package(s), similar to --target-dir.