### PR TITLE
Add --source-dir option to install command.

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -43,7 +43,9 @@ exports.usage = '' +
 '\n' +
 'Options:\n' +
 '  --repository   Source repository URL (otherwise uses values in kansorc)\n' +
-'  --package-dir  Output directory (defaults to "./packages")';
+'  --package-dir  Output directory (defaults to "./packages")\n' +
+'  --source-dir   Local directory to source dependencies from, \n' + 
+'                 accepts semicolon delimited list of directories';
 
 
 /**
@@ -56,12 +58,16 @@ exports.usage = '' +
 exports.run = function (settings, args) {
     var a = argParse(args, {
         'repository': {match: '--repository', value: true},
-        'target_dir': {match: '--package-dir', value: true}
+        'target_dir': {match: '--package-dir', value: true},
+        'source_dir': {match: '--source-dir', value: true}
     });
 
     var opt = a.options;
     var pkg = a.positional[0] || '.';
 
+    if (opt.source_dir) {
+        opt.source_dir = opt.source_dir.split(';').reverse();
+    }
     opt.repositories = settings.repositories;
     if (a.options.repository) {
         opt.repositories = [a.options.repository];
@@ -116,17 +122,20 @@ exports.install = function (pkg, opt, callback) {
 
 
 /**
- * Creates a source function to check packages already in local target_dir.
+ * Creates a source function to check packages on the local filesystem 
+ * either already in target_dir or elsewhere.
  * This can be used in conjunction with the tree module.
  *
  * @param {String} target_dir - the directory we're installing packages to
+ * @param {String} type       - 'local' for target_dir and 'tmp' for elsewhere
  * @returns {Function}
  */
 
 // TODO: also check package_paths (not just target_dir) for available versions?
-exports.dirSource = function (target_dir) {
+exports.dirSource = function (target_dir, type) {
+    type = type || 'local';
     return function (name, callback) {
-        packages.availableVersions([path.join(target_dir, name)], callback);
+        packages.availableVersions([path.join(target_dir, name)], type, callback);
     };
 };
 
@@ -199,9 +208,14 @@ exports.installDir = function (dir, opt, callback) {
             return callback();
         }
         var sources = [
-            exports.dirSource(opt.target_dir),
+            exports.dirSource(opt.target_dir, 'local'),
             exports.repoSource(opt.repositories)
         ];
+        if (opt.source_dir) {
+            opt.source_dir.forEach(function(dir) {
+                sources.unshift(exports.dirSource(dir, 'tmp'));
+            });
+        }
         var pkg = {
             config: cfg,
             source: 'root'
@@ -274,9 +288,14 @@ exports.installName = function (name, opt, callback) {
             return callback(err);
         }
         var sources = [
-            exports.dirSource(opt.target_dir),
+            exports.dirSource(opt.target_dir, 'local'),
             exports.repoSource(opt.repositories)
         ];
+        if (opt.source_dir) {
+            opt.source_dir.forEach(function(dir) {
+                sources.unshift(exports.dirSource(dir, 'tmp'));
+            });
+        }
         var pkg1 = {
             config: cfg,
             source: 'root'
@@ -496,9 +515,14 @@ exports.installFile = function (filename, opt, callback) {
                 return callback(err);
             }
             var sources = [
-                exports.dirSource(opt.target_dir),
+                exports.dirSource(opt.target_dir, 'local'),
                 exports.repoSource(opt.repositories)
             ];
+            if (opt.source_dir) {
+                opt.source_dir.forEach(function(dir) {
+                    sources.unshift(exports.dirSource(dir, 'tmp'));
+                });
+            }
             var packages = exports.prepareTree(cfg, filename, tdir);
             var root = {
                 config: rootcfg,

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -45,7 +45,7 @@ exports.usage = '' +
 '  --repository   Source repository URL (otherwise uses values in kansorc)\n' +
 '  --package-dir  Output directory (defaults to "./packages")\n' +
 '  --source-dir   Local directory to source dependencies from, \n' + 
-'                 accepts semicolon delimited list of directories';
+'                 accepts colon delimited list of directories';
 
 
 /**
@@ -66,7 +66,7 @@ exports.run = function (settings, args) {
     var pkg = a.positional[0] || '.';
 
     if (opt.source_dir) {
-        opt.source_dir = opt.source_dir.split(';').reverse();
+        opt.source_dir = opt.source_dir.split(':').reverse();
     }
     opt.repositories = settings.repositories;
     if (a.options.repository) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -29,7 +29,7 @@ exports.usage = '' +
 '  --repository   Source repository URL (otherwise uses values in kansorc)\n' +
 '  --package-dir  Package directory (defaults to "./packages")\n' + 
 '  --source-dir   Local directory to source dependencies from, \n' + 
-'                 accepts semicolon delimited list of directories';
+'                 accepts colon delimited list of directories';
 
 
 /**
@@ -50,7 +50,7 @@ exports.run = function (settings, args) {
     var deps = a.positional;
 
     if (opt.source_dir) {
-        opt.source_dir = opt.source_dir.split(';').reverse();
+        opt.source_dir = opt.source_dir.split(':').reverse();
     }
     opt.target_dir = opt.target_dir || utils.abspath('packages');
     opt.repositories = settings.repositories;

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -113,12 +113,6 @@ exports.buildTrees = function (deps, cfg, opt, callback) {
         install.dirSource(opt.target_dir, 'local'),
         install.repoSource(opt.repositories)
     ];
-    /*
-    if (opt.source_dir) {
-        opt.source_dir.forEach(function(dir) {
-            local_sources.unshift(install.dirSource(dir, 'tmp'));
-        });
-    }*/
     var pkg = {
         config: cfg,
         source: 'root'

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -27,7 +27,9 @@ exports.usage = '' +
 '\n' +
 'Options:\n' +
 '  --repository   Source repository URL (otherwise uses values in kansorc)\n' +
-'  --package-dir  Package directory (defaults to "./packages")';
+'  --package-dir  Package directory (defaults to "./packages")\n' + 
+'  --source-dir   Local directory to source dependencies from, \n' + 
+'                 accepts semicolon delimited list of directories';
 
 
 /**
@@ -40,12 +42,16 @@ exports.usage = '' +
 exports.run = function (settings, args) {
     var a = argParse(args, {
         'repository': {match: '--repository', value: true},
-        'target_dir': {match: '--package-dir', value: true}
+        'target_dir': {match: '--package-dir', value: true},
+        'source_dir': {match: '--source-dir', value: true}
     });
 
     var opt = a.options;
     var deps = a.positional;
 
+    if (opt.source_dir) {
+        opt.source_dir = opt.source_dir.split(';').reverse();
+    }
     opt.target_dir = opt.target_dir || utils.abspath('packages');
     opt.repositories = settings.repositories;
     if (a.options.repository) {
@@ -104,9 +110,15 @@ exports.update = function (deps, opt, callback) {
 
 exports.buildTrees = function (deps, cfg, opt, callback) {
     var local_sources = [
-        install.dirSource(opt.target_dir),
+        install.dirSource(opt.target_dir, 'local'),
         install.repoSource(opt.repositories)
     ];
+    /*
+    if (opt.source_dir) {
+        opt.source_dir.forEach(function(dir) {
+            local_sources.unshift(install.dirSource(dir, 'tmp'));
+        });
+    }*/
     var pkg = {
         config: cfg,
         source: 'root'
@@ -119,13 +131,24 @@ exports.buildTrees = function (deps, cfg, opt, callback) {
         var update_sources = [
             // check remote source first to make sure we get highest version
             install.repoSource(opt.repositories),
-            install.dirSource(opt.target_dir)
+            install.dirSource(opt.target_dir, 'local')
         ];
         var dependency_sources = [
             // check local source first to keep local version if possible
-            install.dirSource(opt.target_dir),
+            install.dirSource(opt.target_dir, 'local'),
             install.repoSource(opt.repositories)
         ];
+        if (opt.source_dir) {
+            opt.source_dir.forEach(function(dir) {
+                update_sources.unshift(install.dirSource(dir, 'tmp'));
+            });
+            // create a reversed copy since we're adding from another end
+            // to keep the search order the same
+            Array.prototype.slice.call(opt.source_dir).reverse().forEach(
+            function(dir) {
+                dependency_sources.push(install.dirSource(dir, 'tmp'));
+            });
+        }
         if (!deps || !deps.length) {
             // update all packages if none specified
             deps = Object.keys(local);
@@ -187,7 +210,13 @@ exports.getOutdated = function (deps, cfg, opt, callback) {
                 }
             }
             if (!local[name] && updated[name] || lversion !== uversion) {
-                return {name: name, version: uversion, old: lversion};
+                return {
+                    name:    name,
+                    version: uversion, 
+                    old:     lversion,
+                    source:  updated[name].versions[uversion].source || null,
+                    path:    updated[name].versions[uversion].path   || null
+                };
             }
         });
         callback(null, _.compact(changed), local, updated);
@@ -221,6 +250,10 @@ exports.installChanges = function (packages, opt, callback) {
                 dep.name + '@' + dep.old + ' => ' + dep.name + '@' + dep.version
             );
         }
-        install.installRepo(dep.name, dep.version, opt, cb);
+        if (dep.source && dep.source === 'tmp') {
+            install.cpDir(dep.name, dep.version, false, dep.path, opt, cb);
+        } else {
+            install.installRepo(dep.name, dep.version, opt, cb);
+        }
     }, callback);
 };

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -436,10 +436,12 @@ exports.resolveCandidates = function (name, source, paths) {
  * that version, because it comes before pathB in the candidates array.
  *
  * @param {Array} candidates - an array of possible package paths
+ * @param {String} type      - 'local' for the package already in target_dir or
+ *                             'tmp' for package located elsewhere
  * @param {Function} callback
  */
 
-exports.availableVersions = function (candidates, callback) {
+exports.availableVersions = function (candidates, type, callback) {
     var versions = {};
     async.forEach(candidates, function (c, cb) {
         pathExists(path.join(c, 'kanso.json'), function (exists) {
@@ -452,7 +454,7 @@ exports.availableVersions = function (candidates, callback) {
                         versions[doc.version] = {
                             path: c,
                             config: doc,
-                            source: 'local'
+                            source: type
                         };
                     }
                     cb();
@@ -486,7 +488,7 @@ exports.resolve = async.memoize(function (name, ranges, paths, source, callback)
     source = source || process.cwd();
     var candidates = exports.resolveCandidates(name, source, paths);
 
-    exports.availableVersions(candidates, function (err, matches) {
+    exports.availableVersions(candidates, 'local', function (err, matches) {
         if (err) {
             return callback(err);
         }


### PR DESCRIPTION

Allows to resolve dependencies from local packages without publishing
them. In my case I use multiple packages which all depend on a
common package with some common code and functionality. There's no sense in
publishing it, because it is highly app-specific.

--source-dir option should point to the directory above the local
package(s), similar to --target-dir.

--source-dir supports multiple directories separated by semicolon ';'.
Directories are searched in the order given, left to right.
