### PR TITLE
handle C: prefix and backslash in abspath

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -425,7 +425,7 @@ exports.rm = function (/* optional */options, target, callback) {
  */
 
 exports.abspath = function (p, /*optional*/cwd) {
-    if (p[0] === '/') {
+    if (p[0] === '/' || p[1] === ':' || p[0] === '\') {
         return p;
     }
     cwd = cwd || process.cwd();


### PR DESCRIPTION
fix the problem 

    $ kanso push http://localhost:5984/roomedit
    Reading dependency tree...
    Error: Cannot find package 'C:\cygwin64\home\tammikj\roomedit\C:\cygwin64\home\tammikj\roomedit'

discussed in 

https://github.com/kanso/kanso/issues/360