### PR TITLE
Fix kanso push --id= option

### DIFF
--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -74,10 +74,11 @@ exports.run = function (settings, args) {
             }
 
             // these options will override values in kanso.json
-            // the 'id' and 'open' options are not relevant to that data
+            // the 'open' option is not relevant to that data
             var opt = env.overrides || {};
             opt.minify = a.options.minify;
             opt.baseURL = a.options.baseURL;
+            opt.id = a.options.id;
 
             exports.loadApp(dir, url, opt, settings,
                 function (err, url, cfg, doc) {


### PR DESCRIPTION
Previously `--id` arg seemed to be deliberately ignored.  I don't think this
behaviour was correct.  This change updates behaviour to mirror documentation.